### PR TITLE
Fix version comparison, minor update for hyperglot 0.7.0

### DIFF
--- a/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/__init__.py
+++ b/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/__init__.py
@@ -36,7 +36,7 @@ try:
 except ModuleNotFoundError:
   hyperglot = None
 
-HYPERGLOT_MIN_VER = "0.6.4"
+HYPERGLOT_MIN_VER = "0.7.0"
 MIN_COLUMN_WIDTH = 20
 
 def main():
@@ -700,7 +700,7 @@ class TalkingLeaves:
       except Exception:
         # Not critical, so if anything goes wrong we can just check for updates again on next launch
         return
-      if metadata['info']['version'] != hyperglot.__version__:
+      if utils.SimpleVersion(metadata['info']['version']) > utils.SimpleVersion(hyperglot.__version__):
         import sys
         pythonVersion = '.'.join([str(x) for x in sys.version_info][:3])
         message = f"Hyperglot {metadata['info']['version']} is now available, but you have {hyperglot.__version__}.\n\nTo update, copy the following command, then paste it into Terminal:\n\npip3 install --python-version={pythonVersion} --only-binary=:all: --target=\"/Users/$USER/Library/Application Support/Glyphs 3/Scripts/site-packages\" --upgrade hyperglot\n\nThen, restart Glyphs."

--- a/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/data.py
+++ b/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/data.py
@@ -82,8 +82,9 @@ class DataSourceHyperglot(DataSource):
     import hyperglot.languages
     import hyperglot.language
     import hyperglot.orthography
+    from hyperglot.loader import load_scripts_data
 
-    self._scriptNames = hyperglot.orthography.get_scripts()
+    self._scriptNames = load_scripts_data()
 
     hg = hyperglot.languages.Languages()
     for iso in hg.keys():

--- a/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/utils.py
+++ b/TalkingLeaves.glyphsPlugin/Contents/Resources/TalkingLeaves/utils.py
@@ -22,6 +22,8 @@ class SimpleVersion:
     for i, p in enumerate(self.parts):
       if p < other.parts[i]:
         return True
+      if p > other.parts[i]:
+        return False
 
 def bundleResourcesDir(asString=False):
   if asString:


### PR DESCRIPTION
We just released an update to Hyperglot and I went to test the plugin to see if everything fares. I noticed the version comparison would behave erroneously if the installed version was actually higher than the requirement. There is only one minor Hyperglot 0.7.0 specific update to do with how `load_scripts_data` was refactored. 0.7.0 should also load the plugin window a lot faster (after the first time use).

Please do test this once more yourself, just to make sure the plugin and library version integration in my tests was correct.